### PR TITLE
Play a confirmation message after the voicemail has been saved

### DIFF
--- a/lib/voicemail/call_controllers/voicemail_controller.rb
+++ b/lib/voicemail/call_controllers/voicemail_controller.rb
@@ -9,6 +9,7 @@ module Voicemail
         play_greeting
         answer if config.when_to_answer == :after_greeting
         record_message
+        play_recording_confirmation
         hangup
       else
         mailbox_not_found
@@ -17,6 +18,10 @@ module Voicemail
 
     def play_greeting
       play mailbox[:greeting_message] || config.default_greeting
+    end
+
+    def play_recording_confirmation
+      play config.recording_confirmation
     end
 
     def record_message

--- a/lib/voicemail/plugin.rb
+++ b/lib/voicemail/plugin.rb
@@ -28,6 +28,7 @@ module Voicemail
 
       allow_rerecording true, desc: "Allow caller to rerecord their voicemail"
       after_record "Press 1 to save your voicemail.  Press 2 to rerecord.", desc: "Message to play if allow_rerecording is set"
+      recording_confirmation "Your message has been saved. Thank you.", desc: "Message to play after the voicemail has been saved"
 
       desc "Default recording options"
       recording {

--- a/spec/voicemail/call_controllers/voicemail_controller_spec.rb
+++ b/spec/voicemail/call_controllers/voicemail_controller_spec.rb
@@ -46,6 +46,7 @@ describe Voicemail::VoicemailController do
           it "plays the default greeting if one is not specified" do
             should_play config.default_greeting
             subject.should_receive :record_message
+            should_play config.recording_confirmation
             controller.run
           end
         end
@@ -56,6 +57,7 @@ describe Voicemail::VoicemailController do
           it "plays the specific greeting message" do
             should_play greeting_message
             subject.should_receive :record_message
+            should_play config.recording_confirmation
             controller.run
           end
         end

--- a/templates/en.yml
+++ b/templates/en.yml
@@ -40,6 +40,7 @@ en:
       menu_failure_message: "Sorry, unable to understand your input."
 
     after_record: "Press 1 to save your voicemail.  Press 2 to rerecord."
+    recording_confirmation: "Your message has been saved. Thank you."
 
     set_greeting:
       prompt: "Press 1 to listen to your current greeting, 2 to record a new greeting, 9 to return to the main menu."


### PR DESCRIPTION
Repat of PR: https://github.com/adhearsion/voicemail/pull/34
- Adds a new i18n string: 'recording_confirmation'
- Plays back :recording_confirmation before terminating the call after a voicemail has been successfully saved
